### PR TITLE
Add optional country flag to header

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1107,6 +1107,10 @@
         "menu_color_scheme": {
           "label": "Menu color scheme"
         },
+        "country_flag": {
+          "label": "Country flag",
+          "info": "Select an optional flag image to display beside the logo"
+        },
         "sticky_header_type": {
           "label": "Sticky header",
           "options__1": {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -60,6 +60,30 @@
     line-height: calc(1 + 0.8 / var(--font-body-scale));
   }
 
+  .header__brand {
+    display: flex;
+    align-items: center;
+  }
+
+  .header__logo-divider {
+    border-left: 1px solid rgba(var(--color-foreground), 0.2);
+    height: 1.6rem;
+    margin: 0 0.8rem;
+  }
+
+  .header__country-flag {
+    display: block;
+    height: 1.6rem;
+    width: auto;
+  }
+
+  @media screen and (max-width: 380px) {
+    .header__logo-divider,
+    .header__country-flag {
+      display: none;
+    }
+  }
+
   @media screen and (min-width: 750px) {
     .list-menu__item--link {
       padding-bottom: 0.5rem;
@@ -129,6 +153,7 @@
       {%- if request.page_type == 'index' -%}
         <h1 class="header__heading">
       {%- endif -%}
+        <div class="header__brand">
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
             {%- if settings.logo != blank -%}
               <div class="header__heading-logo-wrapper">
@@ -150,6 +175,11 @@
               <span class="h2">{{ shop.name }}</span>
             {%- endif -%}
           </a>
+          {%- if section.settings.country_flag_image != blank -%}
+            <span class="header__logo-divider" aria-hidden="true"></span>
+            {{ section.settings.country_flag_image | image_url: width: 32 | image_tag: class: 'header__country-flag', widths: '32 64', alt: section.settings.country_flag_image.alt | escape }}
+          {%- endif -%}
+        </div>
       {%- if request.page_type == 'index' -%}
         </h1>
       {%- endif -%}
@@ -169,6 +199,7 @@
       {%- if request.page_type == 'index' -%}
         <h1 class="header__heading">
       {%- endif -%}
+        <div class="header__brand">
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
             {%- if settings.logo != blank -%}
               <div class="header__heading-logo-wrapper">
@@ -190,6 +221,11 @@
               <span class="h2">{{ shop.name }}</span>
             {%- endif -%}
           </a>
+          {%- if section.settings.country_flag_image != blank -%}
+            <span class="header__logo-divider" aria-hidden="true"></span>
+            {{ section.settings.country_flag_image | image_url: width: 32 | image_tag: class: 'header__country-flag', widths: '32 64', alt: section.settings.country_flag_image.alt | escape }}
+          {%- endif -%}
+        </div>
       {%- if request.page_type == 'index' -%}
         </h1>
       {%- endif -%}
@@ -536,6 +572,12 @@
       "id": "menu_color_scheme",
       "label": "t:sections.header.settings.menu_color_scheme.label",
       "default": "scheme-1"
+    },
+    {
+      "type": "image_picker",
+      "id": "country_flag_image",
+      "label": "t:sections.header.settings.country_flag.label",
+      "info": "t:sections.header.settings.country_flag.info"
     },
     {
       "type": "header",


### PR DESCRIPTION
## Summary
- add new setting `country_flag` for uploading an optional flag image
- render flag image next to header logo with divider
- hide divider and flag on very small screens
- revert whitespace-only locale changes

## Testing
- `npx prettier -w locales/en.default.schema.json` *(fails: cannot find module - plugin not installed)*