### PR TITLE
Add optional flag via country code

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1107,6 +1107,10 @@
         "menu_color_scheme": {
           "label": "Menu color scheme"
         },
+        "country_flag": {
+          "label": "Country flag",
+          "info": "Enter a two-letter country code to display its flag next to the logo"
+        },
         "sticky_header_type": {
           "label": "Sticky header",
           "options__1": {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -68,16 +68,16 @@
   .header__logo-divider {
     border-left: 1px solid rgba(var(--color-foreground), 0.2);
     height: 1.6rem;
-    margin: 0 0.8rem;
+    margin: 0 1.4rem 0 0.8rem
   }
 
   .header__country-flag {
     display: block;
-    height: 1.6rem;
+    height: 1.9rem;
     width: auto;
   }
 
-  @media screen and (max-width: 380px) {
+  @media screen and (max-width: 350px) {
     .header__logo-divider,
     .header__country-flag {
       display: none;
@@ -177,7 +177,7 @@
           </a>
           {%- if section.settings.country_flag_code != blank -%}
             <span class="header__logo-divider" aria-hidden="true"></span>
-            <img src="https://flagcdn.com/24x18/{{ section.settings.country_flag_code | downcase }}.png" class="header__country-flag" width="24" height="18" alt="{{ section.settings.country_flag_code }}">
+            <img src="https://flagcdn.com/h80/{{ section.settings.country_flag_code | downcase }}.png" class="header__country-flag" width="24" height="18" alt="{{ section.settings.country_flag_code }}">
           {%- endif -%}
         </div>
       {%- if request.page_type == 'index' -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -60,6 +60,30 @@
     line-height: calc(1 + 0.8 / var(--font-body-scale));
   }
 
+  .header__brand {
+    display: flex;
+    align-items: center;
+  }
+
+  .header__logo-divider {
+    border-left: 1px solid rgba(var(--color-foreground), 0.2);
+    height: 1.6rem;
+    margin: 0 0.8rem;
+  }
+
+  .header__country-flag {
+    display: block;
+    height: 1.6rem;
+    width: auto;
+  }
+
+  @media screen and (max-width: 380px) {
+    .header__logo-divider,
+    .header__country-flag {
+      display: none;
+    }
+  }
+
   @media screen and (min-width: 750px) {
     .list-menu__item--link {
       padding-bottom: 0.5rem;
@@ -129,6 +153,7 @@
       {%- if request.page_type == 'index' -%}
         <h1 class="header__heading">
       {%- endif -%}
+        <div class="header__brand">
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
             {%- if settings.logo != blank -%}
               <div class="header__heading-logo-wrapper">
@@ -150,6 +175,11 @@
               <span class="h2">{{ shop.name }}</span>
             {%- endif -%}
           </a>
+          {%- if section.settings.country_flag_code != blank -%}
+            <span class="header__logo-divider" aria-hidden="true"></span>
+            <img src="https://flagcdn.com/24x18/{{ section.settings.country_flag_code | downcase }}.png" class="header__country-flag" width="24" height="18" alt="{{ section.settings.country_flag_code }}">
+          {%- endif -%}
+        </div>
       {%- if request.page_type == 'index' -%}
         </h1>
       {%- endif -%}
@@ -169,6 +199,7 @@
       {%- if request.page_type == 'index' -%}
         <h1 class="header__heading">
       {%- endif -%}
+        <div class="header__brand">
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
             {%- if settings.logo != blank -%}
               <div class="header__heading-logo-wrapper">
@@ -190,6 +221,11 @@
               <span class="h2">{{ shop.name }}</span>
             {%- endif -%}
           </a>
+          {%- if section.settings.country_flag_code != blank -%}
+            <span class="header__logo-divider" aria-hidden="true"></span>
+            <img src="https://flagcdn.com/24x18/{{ section.settings.country_flag_code | downcase }}.png" class="header__country-flag" width="24" height="18" alt="{{ section.settings.country_flag_code }}">
+          {%- endif -%}
+        </div>
       {%- if request.page_type == 'index' -%}
         </h1>
       {%- endif -%}
@@ -536,6 +572,12 @@
       "id": "menu_color_scheme",
       "label": "t:sections.header.settings.menu_color_scheme.label",
       "default": "scheme-1"
+    },
+    {
+      "type": "text",
+      "id": "country_flag_code",
+      "label": "t:sections.header.settings.country_flag.label",
+      "info": "t:sections.header.settings.country_flag.info"
     },
     {
       "type": "header",


### PR DESCRIPTION
## Summary
- show a user-entered country flag beside the logo
- hide the flag and divider on narrow screens
- use a text input for the country code instead of an image picker

## Testing
- `npx prettier -w locales/en.default.schema.json`
- `npx prettier -w sections/header.liquid` *(fails: No parser could be inferred)*