### PR TITLE
Show out of stock tag on collection cards

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2992,6 +2992,7 @@ details-disclosure > details {
   border-color: rgba(var(--color-badge-border), var(--alpha-badge-border));
   color: rgb(var(--color-badge-foreground));
   word-break: break-word;
+  overflow:hidden;
 }
 
 .badge::after {

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -181,6 +181,13 @@
                     {{ saving_percentage }}% OFF
                   {% endif %}
                 </span>
+              {%- elsif card_variant.available == false and disabled == false -%}
+                <span
+                  id="NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}-{{ card_variant.id }}"
+                  class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}"
+                >
+                  {{ 'products.product.inventory_out_of_stock' | t }}
+                </span>
               {%- endif -%}
             {%- else -%}
               {%- if card_product.available == true
@@ -200,6 +207,13 @@
                     %}
                     {{ saving_percentage }}% OFF
                   {% endif %}
+                </span>
+              {% elsif card_product.available == false and disabled == false %}
+                <span
+                  id="NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}"
+                  class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}"
+                >
+                  {{ 'products.product.inventory_out_of_stock' | t }}
                 </span>
               {% elsif card_product.metafields.custom_but_hidden.product_tag != null %}
                 <span
@@ -631,7 +645,11 @@
               id="Badge-{{ section_id }}-{{ card_product.id }}"
               class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}"
             >
-              {{- 'products.product.sold_out' | t -}}
+              {%- if disabled == false -%}
+                {{- 'products.product.inventory_out_of_stock' | t -}}
+              {%- else -%}
+                {{- 'products.product.sold_out' | t -}}
+              {%- endif -%}
             </span>
           {%- elsif card_product.compare_at_price > card_product.price and card_product.available -%}
             <span

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -641,16 +641,6 @@
         {% endif %}
         <div class="card__badge {{ settings.badge_position }}">
           {%- if card_product.available == false -%}
-            <span
-              id="Badge-{{ section_id }}-{{ card_product.id }}"
-              class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}"
-            >
-              {%- if disabled == false -%}
-                {{- 'products.product.inventory_out_of_stock' | t -}}
-              {%- else -%}
-                {{- 'products.product.sold_out' | t -}}
-              {%- endif -%}
-            </span>
           {%- elsif card_product.compare_at_price > card_product.price and card_product.available -%}
             <span
               id="Badge-{{ section_id }}-{{ card_product.id }}"


### PR DESCRIPTION
## Summary
- show an `Out of stock` badge alongside custom product tags when the product is unavailable and grey-out is disabled

## Testing
- `npm exec prettier -- --check snippets/card-product.liquid`
